### PR TITLE
corrección de alerta y fecha

### DIFF
--- a/view/cobro/index.php
+++ b/view/cobro/index.php
@@ -355,7 +355,7 @@ $menu->footer();
                     "data": "concepto_cobro"
                 },
                 {
-                    "data": "fecha_cobro"
+                    "data": "fechalimite_cobro"
                 },
                 {
                     data: null,

--- a/view/pago/index.php
+++ b/view/pago/index.php
@@ -422,18 +422,19 @@ $menu->footer();
                     success: function(data) {
                         if (data == 'ok') {
                             Swal.fire(
-                                "¡Error!",
-                                "Ha ocurrido un error al registrar el pago. " + data,
-                                "error"
-                            );
-                        } else {
-                            Swal.fire(
                                 "¡Éxito!",
                                 "El pago ha sido registrado de manera correcta",
                                 "success"
                             ).then(function() {
                                 window.location = "<?php echo constant('URL'); ?>pago";
                             })
+                            
+                        } else {
+                            Swal.fire(
+                                "¡Error!",
+                                "Ha ocurrido un error al registrar el pago. " + data,
+                                "error"
+                            );
                         }
                     },
                 });


### PR DESCRIPTION
1. Ya se muestra la fecha correctamente en cobro.
2. Al registrar un pago ya se muestra la alerta que corresponde.